### PR TITLE
htmlエスケープをしたときに表示が崩れるのを修正

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -71,15 +71,15 @@ end
 helpers do
   def to_link(notes)
     notes.map do |note|
-      "<a href='/note/#{note['id']}'>#{justify_title(note['title'])}</a>"
+      "<a href='/note/#{note['id']}'>#{justify_title(note['title'], 50)}</a>"
     end
   end
-  
+
   def to_ul(a_tags)
     li_tags = a_tags.map do |atag|
       "<li>#{atag}</li>"
     end.join
-  
+
     "<ul>#{li_tags}</ul>"
   end
 

--- a/lib/crud_controller.rb
+++ b/lib/crud_controller.rb
@@ -4,7 +4,7 @@ FILE_DIR = Pathname(__dir__).join('../public/notes')
 
 def read_main
   file_path = FILE_DIR.join('*.json')
-  notes = retrieve_json_file(file_path)
+  retrieve_json_file(file_path)
 end
 
 def retrieve_json_file(file_path)
@@ -13,7 +13,7 @@ def retrieve_json_file(file_path)
   files_paths.map do |path_name|
     File.open(path_name) do |json_file|
       json_object = JSON.parse(json_file.read)
-      { 'id' => json_object['id'], 'title' => json_object['title'] }
+      { 'id' => escape_processing(json_object['id']), 'title' => escape_processing(json_object['title']) }
     end
   end
 end
@@ -22,8 +22,13 @@ def sort_notes(notes)
   notes.sort_by { |note| note.values_at('id') }.reverse
 end
 
-def justify_title(title)
-  title.length > 19 ? "#{title[0..19]}…" : title
+def justify_title(title_string, max_byte_size)
+  return_string = +''
+  title_string.chars.each do |string|
+    return_string.bytesize < max_byte_size ? return_string << string : break
+  end
+
+  "#{return_string}..."
 end
 
 def read_note(id)
@@ -60,7 +65,7 @@ end
 
 def update_main(file_id, title, body)
   file_path = FILE_DIR.join("#{file_id}.json")
-  hash = { 'id' => file_id.to_i, 'title' => title, 'body' => body }
+  hash = { 'id' => file_id.to_i, 'title' => escape_processing(title), 'body' => escape_processing(body) }
   edit_file(file_path, hash)
 end
 

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -160,6 +160,10 @@ div.wrapping-form-div {
   opacity: 0.7;
 }
 
+p.note-title {
+  overflow: hidden;
+}
+
 p.note-title, p.note-body, textarea.note-body-readonly{
   width: 100%;
   background-color: white !important;


### PR DESCRIPTION
エスケープしたときに文字列が長くなりすぎて、そのために要素からはみ出ることが原因だった。